### PR TITLE
Fix typo

### DIFF
--- a/src/models/sequence/ss/s4_simple/README.md
+++ b/src/models/sequence/ss/s4_simple/README.md
@@ -20,7 +20,7 @@ By default, the kernel ignores the initial state (fusing `b` and `c`), and only 
 You can play with these parameters in the training run:
 * Adding `use_initial=true` will add a learnable initial state, and learn the `b` and `c` parameters separately.
 * Setting `learn_theta=true` will make the `theta` parameters learnable (we usually see a decrease in performance of about 3 points from this).
-* Setting `leran_a=false` will make the `a` parameters not learnable. We don't see much of a performance degradation on CIFAR in this case, which speaks to the utility of the Chebyshev initialization!
+* Setting `learn_a=false` will make the `a` parameters not learnable. We don't see much of a performance degradation on CIFAR in this case, which speaks to the utility of the Chebyshev initialization!
 * Setting `zero_order_hold=false` will switch from Zero-Order Hold to left-end-point quadrature. Additionally setting `trap_rule=true` will switch to the trapezoid rule (when `zero_order_hold` is set to `false`).
 
 ## Other Files


### PR DESCRIPTION
L22: Setting `learn_theta=true` (before was something else)