### PR TITLE
Fix import in example.py and a possible typo in models/s4/s4d.py

### DIFF
--- a/example.py
+++ b/example.py
@@ -32,8 +32,8 @@ import torchvision.transforms as transforms
 import os
 import argparse
 
-from src.models.s4.s4 import S4
-from src.models.s4.s4d import S4D
+from models.s4.s4 import S4
+from models.s4.s4d import S4D
 from tqdm.auto import tqdm
 
 # Dropout broke in PyTorch 1.11

--- a/models/s4/s4d.py
+++ b/models/s4/s4d.py
@@ -20,7 +20,7 @@ class S4DKernel(nn.Module):
         ) + math.log(dt_min)
 
         C = torch.randn(H, N // 2, dtype=torch.cfloat)
-        self.C = nn.Parameter(torch.view_as_view(C))
+        self.C = nn.Parameter(torch.view_as_real(C))
         self.register("log_dt", log_dt, lr)
 
         log_A_real = torch.log(0.5 * torch.ones(H, N//2))


### PR DESCRIPTION
I found that I cannot run the example program. It seems that there are two issues.

1. In `example.py`, `S4` and `S4D` are imported from `src.models.s4`. However, they have been moved to `models.s4`
2. In `models/s4/s4d.py`, `torch.view_as_view` is called. I believe this is a typo as I do not find any document related to this function. I think it is supposed to be `torch.view_as_real`

Training starts with these changes.